### PR TITLE
feat: filter blocked users

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,6 +132,7 @@ async function getUsersInTopic(uid, tid, composing) {
 
 		let userData = await user.getUsersFields(userIds, ['uid', 'username', 'userslug', 'picture', 'status']);
 		userData = userData.filter(user => user && parseInt(user.uid, 10) > 0 && user.status !== 'offline').slice(0, settings.numUsers);
+		userData = await user.blocks.filter(uid, userData);
 
 		userData.forEach(function (user) {
 			user.composing = composingUsers.includes(user.uid);


### PR DESCRIPTION
Hides users one has blocked from their list of browsing users in a topic.

(Additionally resolves oplik0/nodebb-plugin-two-way-block/issues/61, so that plugin will also hide people who have blocked a user from them)